### PR TITLE
Fix hami ui bug

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,8 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
       - v[0-9]+.[0-9]+
 
-  pull_request:
-    branches: [ "release-1.0.3" ]
+  # pull_request:
+  #   branches: [ "release-1.0.3" ]
 
 env:
   GO_VERSION: "1.22.5"
@@ -45,6 +45,36 @@ jobs:
           sbom: true
           provenance: true
           tags: registry.rancher.cn/cnrancher/hami-webui-fe-oss:${{ steps.branch-names.outputs.current_branch || steps.branch-names.outputs.tag }}
+  build-and-push-backend:
+    name: Build and Push Backend Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get branch names.
+        id: branch-names
+        uses: tj-actions/branch-names@v8
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3.1.0
+        with:
+          registry: registry.rancher.cn
+          username: ${{ secrets.TCR_USERNAME }}
+          password: ${{ secrets.TCR_TOKEN }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./server
+          platforms: linux/amd64,linux/arm64
+          push: true
+          sbom: true
+          provenance: true
+          tags: registry.rancher.cn/cnrancher/hami-webui-be-oss:${{ steps.branch-names.outputs.current_branch || steps.branch-names.outputs.tag }}
 
   image-sign:
     permissions:
@@ -70,6 +100,7 @@ jobs:
         version: v1.9.0
         images: |
           registry.rancher.cn/cnrancher/hami-webui-fe-oss:${{ steps.branch-names.outputs.current_branch || steps.branch-names.outputs.tag }}
+          registry.rancher.cn/cnrancher/hami-webui-be-oss:${{ steps.branch-names.outputs.current_branch || steps.branch-names.outputs.tag }}
 
   # build-and-push-backend:
   #   name: Build and Push Backend Image

--- a/server/internal/provider/util/util.go
+++ b/server/internal/provider/util/util.go
@@ -3,10 +3,11 @@ package util
 import (
 	"errors"
 	"fmt"
-	"github.com/go-kratos/kratos/v2/log"
-	corev1 "k8s.io/api/core/v1"
 	"strconv"
 	"strings"
+
+	"github.com/go-kratos/kratos/v2/log"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -60,7 +61,7 @@ func DecodeNodeDevices(str string, log *log.Helper) ([]*DeviceInfo, error) {
 	for _, val := range tmp {
 		if strings.Contains(val, ",") {
 			items := strings.Split(val, ",")
-			if len(items) == 7 {
+			if len(items) >= 7 { // hami v2.5.0 will contains more than 7 values
 				count, _ := strconv.Atoi(items[1])
 				devmem, _ := strconv.Atoi(items[2])
 				devcore, _ := strconv.Atoi(items[3])


### PR DESCRIPTION
https://github.com/cnrancher/pandaria/issues/3598
https://github.com/cnrancher/pandaria/issues/3597

修复了hami ui在使用hami v2.5.0版本时无法正确显示gpu信息的问题。
问题是由于hami v2.5.0在node annotation中保存的gpu信息增加了新的字段，但hami ui这边按照固定字段数量进行解析导致出错。
另外增加了`hami-webui-be-oss`镜像的CI发布流程。